### PR TITLE
feat: code review remarks by Opus

### DIFF
--- a/app/actions/car/update.ts
+++ b/app/actions/car/update.ts
@@ -1,8 +1,11 @@
+import * as z from 'zod';
 import { Car, carSchema } from '@/domain/car.model';
 import { dbCarUpdate } from '@/storage/car/car.update';
 
 export const updateCar = async (car: Car): Promise<Car> => {
   const validatedCar = carSchema.parse(car);
+  // Ensure id is not null for updates
+  z.uuid().parse(validatedCar.id);
   const result = await dbCarUpdate(validatedCar);
   return result;
 };

--- a/app/api/cars/[id]/route.ts
+++ b/app/api/cars/[id]/route.ts
@@ -1,13 +1,12 @@
 import type { NextRequest } from 'next/server';
-import { IdRouteParams, getIdFromRoute, noContentResponse, tryUpdateResource } from '@/api/utils';
+import { IdRouteParams, getIdFromRoute, tryDeleteResource, tryReadResource, tryUpdateResource } from '@/api/utils';
 import { deleteCar } from '@/actions/car/delete';
 import { updateCar } from '@/actions/car/update';
 import { readCar } from '@/actions/car/read';
 
 export async function GET(request: NextRequest, route: IdRouteParams) {
   const id = await getIdFromRoute(route);
-  const car = await readCar(id);
-  return Response.json(car);
+  return tryReadResource(readCar, id);
 }
 
 export async function PUT(request: NextRequest, route: IdRouteParams) {
@@ -16,6 +15,5 @@ export async function PUT(request: NextRequest, route: IdRouteParams) {
 
 export async function DELETE(request: NextRequest, route: IdRouteParams) {
   const id = await getIdFromRoute(route);
-  await deleteCar(id);
-  return noContentResponse();
+  return tryDeleteResource(deleteCar, id);
 }

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -3,6 +3,7 @@ import { searchCar } from '@/actions/car/search';
 import { createCar } from '@/actions/car/create';
 import { fromZodParseResult, tryCreateResource } from '@/api/utils';
 import { carFilterSchema } from '@/domain/car.filter';
+import { statusCodes } from '@/api/status-codes';
 
 export async function GET(request: NextRequest) {
   const carFilter = carFilterSchema.safeParse(Object.fromEntries(request.nextUrl.searchParams));
@@ -19,6 +20,9 @@ export async function POST(request: NextRequest) {
     return tryCreateResource(createCar, car);
   } catch (error) {
     console.error(error);
-    return Response.json({}, { status: 500 });
+    return Response.json(
+      { code: 'internal_error', errors: [{ message: 'Failed to parse request body' }] },
+      { status: statusCodes.INTERNAL_SERVER_ERROR },
+    );
   }
 }

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -2,15 +2,29 @@ import z, { ZodError, ZodSafeParseResult } from 'zod';
 import { statusCodes } from './status-codes';
 import { NextRequest } from 'next/server';
 
+export class NotFoundError extends Error {
+  constructor(message: string = 'Resource not found') {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
+export const isPrismaNotFoundError = (error: unknown): boolean => {
+  return error !== null && typeof error === 'object' && 'code' in error && (error.code === 'P2025' || error.code === 'P2016');
+};
+
 export const tryCreateResource = async <T>(createResource: (resource: T) => Promise<T>, resource: T): Promise<Response> => {
   try {
     const createdResource = await createResource(resource);
     return Response.json(createdResource, { status: statusCodes.CREATED });
   } catch (error) {
     if (error instanceof ZodError) {
-      return Response.json({}, { status: statusCodes.BAD_REQUEST });
+      return Response.json({ code: 'validation_error', errors: error.issues }, { status: statusCodes.BAD_REQUEST });
     } else {
-      return Response.json({}, { status: statusCodes.INTERNAL_SERVER_ERROR });
+      return Response.json(
+        { code: 'internal_error', errors: [{ message: 'An unexpected error occurred' }] },
+        { status: statusCodes.INTERNAL_SERVER_ERROR },
+      );
     }
   }
 };
@@ -33,11 +47,39 @@ export const noContentResponse = (): Response => {
   return new Response(null, { status: statusCodes.NO_CONTENT });
 };
 
+export const notFoundResponse = (message: string = 'Resource not found'): Response => {
+  return Response.json({ code: 'not_found', errors: [{ message }] }, { status: statusCodes.NOT_FOUND });
+};
+
 const uuidSchema = z.uuid();
 
 export const getIdFromRoute = async (route: IdRouteParams): Promise<string> => {
   const { id } = await route.params;
   return uuidSchema.parse(id);
+};
+
+export const tryReadResource = async <T>(readResource: (id: string) => Promise<T>, id: string): Promise<Response> => {
+  try {
+    const resource = await readResource(id);
+    return Response.json(resource);
+  } catch (error) {
+    if (isPrismaNotFoundError(error) || error instanceof NotFoundError) {
+      return notFoundResponse();
+    }
+    throw error;
+  }
+};
+
+export const tryDeleteResource = async (deleteResource: (id: string) => Promise<void>, id: string): Promise<Response> => {
+  try {
+    await deleteResource(id);
+    return noContentResponse();
+  } catch (error) {
+    if (isPrismaNotFoundError(error) || error instanceof NotFoundError) {
+      return notFoundResponse();
+    }
+    throw error;
+  }
 };
 
 export const tryUpdateResource = async <T>(
@@ -51,7 +93,7 @@ export const tryUpdateResource = async <T>(
   if (data.id !== id) {
     return Response.json(
       {
-        code: 'id mismatch',
+        code: 'id_mismatch',
         errors: [{ message: 'id in body does not match id in path' }],
       },
       { status: statusCodes.BAD_REQUEST },
@@ -62,9 +104,14 @@ export const tryUpdateResource = async <T>(
     return noContentResponse();
   } catch (error) {
     if (error instanceof ZodError) {
-      return Response.json({}, { status: statusCodes.BAD_REQUEST });
+      return Response.json({ code: 'validation_error', errors: error.issues }, { status: statusCodes.BAD_REQUEST });
+    } else if (isPrismaNotFoundError(error) || error instanceof NotFoundError) {
+      return notFoundResponse();
     } else {
-      return Response.json({}, { status: statusCodes.INTERNAL_SERVER_ERROR });
+      return Response.json(
+        { code: 'internal_error', errors: [{ message: 'An unexpected error occurred' }] },
+        { status: statusCodes.INTERNAL_SERVER_ERROR },
+      );
     }
   }
 };

--- a/app/domain/car.filter.ts
+++ b/app/domain/car.filter.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import * as z from 'zod';
 import { DefaultTake, MaxTake, SortOrder } from './utils';
 
 export enum CarSortColumns {

--- a/app/domain/car.model.ts
+++ b/app/domain/car.model.ts
@@ -1,10 +1,12 @@
 import * as z from 'zod';
 
-export const carSchema = z.object({
-  id: z.uuid().nullable(),
-  name: z.string().min(1).max(100),
-  createdAt: z.date().nullable().default(null),
-  updatedAt: z.date().nullable().default(null),
-});
+export const carSchema = z
+  .object({
+    id: z.uuid().nullable(),
+    name: z.string().min(1).max(100),
+    createdAt: z.date().nullable().default(null),
+    updatedAt: z.date().nullable().default(null),
+  })
+  .strict();
 
 export type Car = z.infer<typeof carSchema>;

--- a/app/storage/car/car.create.ts
+++ b/app/storage/car/car.create.ts
@@ -1,5 +1,5 @@
 import { Car } from '@/domain/car.model';
-import { getPrismaClient } from '../utils';
+import { getPrismaClient } from '@/storage/utils';
 import { carToDbCar, dbCarToDomain } from './car.mappers';
 
 export const dbCarCreate = async (car: Car): Promise<Car> => {

--- a/app/storage/car/car.mappers.ts
+++ b/app/storage/car/car.mappers.ts
@@ -15,3 +15,9 @@ export const carToDbCar = (car: Car): Prisma.CarCreateInput => {
     name: car.name,
   };
 };
+
+export const carToDbCarUpdate = (car: Car): Prisma.CarUpdateInput => {
+  return {
+    name: car.name,
+  };
+};

--- a/app/storage/car/car.update.ts
+++ b/app/storage/car/car.update.ts
@@ -1,14 +1,12 @@
 import { Car } from '@/domain/car.model';
-import { getPrismaClient } from '../utils';
-import { dbCarToDomain } from './car.mappers';
+import { getPrismaClient } from '@/storage/utils';
+import { carToDbCarUpdate, dbCarToDomain } from './car.mappers';
 
 export const dbCarUpdate = async (car: Car): Promise<Car> => {
   const prisma = getPrismaClient();
   const updatedCar = await prisma.car.update({
     where: { id: car.id! },
-    data: {
-      name: car.name,
-    },
+    data: carToDbCarUpdate(car),
   });
   return dbCarToDomain(updatedCar);
 };

--- a/app/storage/utils.ts
+++ b/app/storage/utils.ts
@@ -2,12 +2,17 @@ import { PrismaNeon } from '@prisma/adapter-neon';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from './client/client';
 
+let prismaClient: PrismaClient | null = null;
+
 export const getPrismaClient = () => {
+  if (prismaClient) {
+    return prismaClient;
+  }
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL is not set');
   }
-  const prisma = process.env.DATABASE_URL.includes('.neon.tech')
+  prismaClient = process.env.DATABASE_URL.includes('.neon.tech')
     ? new PrismaClient({ adapter: new PrismaNeon({ connectionString: process.env.DATABASE_URL }) })
     : new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }) });
-  return prisma;
+  return prismaClient;
 };

--- a/tests/actions/car/update.spec.ts
+++ b/tests/actions/car/update.spec.ts
@@ -46,5 +46,18 @@ describe('updateCar', () => {
       await expect(updateCar(invalidCar)).rejects.toBeInstanceOf(ZodError);
       expect(dbCarUpdate).not.toHaveBeenCalled();
     });
+
+    it('throws validation error when id is null', async () => {
+      // Don't use builder since it replaces null with default value
+      const carWithNullId = {
+        id: null,
+        name: 'Valid Name',
+        createdAt: null,
+        updatedAt: null,
+      };
+
+      await expect(updateCar(carWithNullId)).rejects.toBeInstanceOf(ZodError);
+      expect(dbCarUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/api/cars/route.spec.ts
+++ b/tests/api/cars/route.spec.ts
@@ -137,7 +137,7 @@ describe('API Route - POST /api/cars', () => {
     expect(createCar).toHaveBeenCalledWith(mockCarInput);
   });
 
-  it('returns 500 when request body is invalid JSON', async () => {
+  it('returns 500 with structured error when request body is invalid JSON', async () => {
     const request = {
       json: vi.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
     } as any;
@@ -146,7 +146,8 @@ describe('API Route - POST /api/cars', () => {
     const json = await response.json();
 
     expect(response.status).toBe(500);
-    expect(json).toEqual({});
+    expect(json.code).toBe('internal_error');
+    expect(json.errors).toBeDefined();
     expect(createCar).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/utils.spec.ts
+++ b/tests/api/utils.spec.ts
@@ -1,8 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { fromZodParseResult, getIdFromRoute, noContentResponse, tryCreateResource, tryUpdateResource } from '@/api/utils';
+import {
+  NotFoundError,
+  fromZodParseResult,
+  getIdFromRoute,
+  isPrismaNotFoundError,
+  noContentResponse,
+  notFoundResponse,
+  tryCreateResource,
+  tryDeleteResource,
+  tryReadResource,
+  tryUpdateResource,
+} from '@/api/utils';
 import { ZodError } from 'zod';
 
 describe('API Utils', () => {
+  describe('isPrismaNotFoundError', () => {
+    it('returns true for P2025 error code', () => {
+      const error = { code: 'P2025' };
+      expect(isPrismaNotFoundError(error)).toBe(true);
+    });
+
+    it('returns true for P2016 error code', () => {
+      const error = { code: 'P2016' };
+      expect(isPrismaNotFoundError(error)).toBe(true);
+    });
+
+    it('returns false for other error codes', () => {
+      const error = { code: 'P2002' };
+      expect(isPrismaNotFoundError(error)).toBe(false);
+    });
+
+    it('returns false for non-object errors', () => {
+      expect(isPrismaNotFoundError(null)).toBe(false);
+      expect(isPrismaNotFoundError('error')).toBe(false);
+    });
+  });
+
   describe('tryCreateResource', () => {
     it('should return a 201 response with created resource for valid data', async () => {
       const mockCreateResource = async (resource: any) => {
@@ -19,7 +52,7 @@ describe('API Utils', () => {
       expect(responseData.name).toBe('Valid Resource');
     });
 
-    it('should return a 400 response for Zod validation error', async () => {
+    it('should return a 400 response with structured error for Zod validation error', async () => {
       const mockCreateResource = async () => {
         throw new ZodError([]);
       };
@@ -27,11 +60,14 @@ describe('API Utils', () => {
       const resource = { name: '' }; // Invalid resource
 
       const response = await tryCreateResource(mockCreateResource, resource);
+      const responseData = await response.json();
 
       expect(response.status).toBe(400);
+      expect(responseData.code).toBe('validation_error');
+      expect(responseData.errors).toBeDefined();
     });
 
-    it('should return a 500 response for non-validation errors', async () => {
+    it('should return a 500 response with structured error for non-validation errors', async () => {
       const mockCreateResource = async () => {
         throw new Error('Non-validation error');
       };
@@ -39,8 +75,11 @@ describe('API Utils', () => {
       const resource = { name: 'Valid Resource' };
 
       const response = await tryCreateResource(mockCreateResource, resource);
+      const responseData = await response.json();
 
       expect(response.status).toBe(500);
+      expect(responseData.code).toBe('internal_error');
+      expect(responseData.errors).toBeDefined();
     });
   });
 
@@ -94,6 +133,22 @@ describe('API Utils', () => {
     });
   });
 
+  describe('notFoundResponse', () => {
+    it('should return a 404 Not Found response with default message', () => {
+      const response = notFoundResponse();
+      expect(response.status).toBe(404);
+    });
+
+    it('should return a 404 Not Found response with custom message', async () => {
+      const response = notFoundResponse('Car not found');
+      const responseData = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(responseData.code).toBe('not_found');
+      expect(responseData.errors[0].message).toBe('Car not found');
+    });
+  });
+
   describe('getIdFromRoute', () => {
     it('should return the id from route params for valid UUID', async () => {
       const validUUID = '123e4567-e89b-12d3-a456-426614174000';
@@ -113,6 +168,86 @@ describe('API Utils', () => {
       };
 
       await expect(getIdFromRoute(mockRoute)).rejects.toThrow();
+    });
+  });
+
+  describe('tryReadResource', () => {
+    it('should return 200 response with resource for successful read', async () => {
+      const mockResource = { id: '123', name: 'Test' };
+      const mockReadResource = async () => mockResource;
+
+      const response = await tryReadResource(mockReadResource, '123');
+      const responseData = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseData).toEqual(mockResource);
+    });
+
+    it('should return 404 response for Prisma not found error', async () => {
+      const mockReadResource = async () => {
+        throw { code: 'P2025' };
+      };
+
+      const response = await tryReadResource(mockReadResource, '123');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 404 response for NotFoundError', async () => {
+      const mockReadResource = async () => {
+        throw new NotFoundError('Resource not found');
+      };
+
+      const response = await tryReadResource(mockReadResource, '123');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should rethrow unexpected errors', async () => {
+      const mockReadResource = async () => {
+        throw new Error('Unexpected error');
+      };
+
+      await expect(tryReadResource(mockReadResource, '123')).rejects.toThrow('Unexpected error');
+    });
+  });
+
+  describe('tryDeleteResource', () => {
+    it('should return 204 response for successful delete', async () => {
+      const mockDeleteResource = async () => {};
+
+      const response = await tryDeleteResource(mockDeleteResource, '123');
+
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+    });
+
+    it('should return 404 response for Prisma not found error', async () => {
+      const mockDeleteResource = async () => {
+        throw { code: 'P2025' };
+      };
+
+      const response = await tryDeleteResource(mockDeleteResource, '123');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 404 response for NotFoundError', async () => {
+      const mockDeleteResource = async () => {
+        throw new NotFoundError('Resource not found');
+      };
+
+      const response = await tryDeleteResource(mockDeleteResource, '123');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should rethrow unexpected errors', async () => {
+      const mockDeleteResource = async () => {
+        throw new Error('Unexpected error');
+      };
+
+      await expect(tryDeleteResource(mockDeleteResource, '123')).rejects.toThrow('Unexpected error');
     });
   });
 
@@ -146,12 +281,12 @@ describe('API Utils', () => {
 
       expect(response.status).toBe(400);
       expect(responseData).toEqual({
-        code: 'id mismatch',
+        code: 'id_mismatch',
         errors: [{ message: 'id in body does not match id in path' }],
       });
     });
 
-    it('should return 400 response for Zod validation error', async () => {
+    it('should return 400 response with structured error for Zod validation error', async () => {
       const mockRequest = {
         json: async () => ({ id: '123e4567-e89b-12d3-a456-426614174000', name: 'Updated Name' }),
       } as any;
@@ -163,11 +298,29 @@ describe('API Utils', () => {
       };
 
       const response = await tryUpdateResource(mockRequest, mockRoute, mockUpdateResource);
+      const responseData = await response.json();
 
       expect(response.status).toBe(400);
+      expect(responseData.code).toBe('validation_error');
     });
 
-    it('should return 500 response for non-validation errors', async () => {
+    it('should return 404 response for Prisma not found error', async () => {
+      const mockRequest = {
+        json: async () => ({ id: '123e4567-e89b-12d3-a456-426614174000', name: 'Updated Name' }),
+      } as any;
+      const mockRoute = {
+        params: Promise.resolve({ id: '123e4567-e89b-12d3-a456-426614174000' }),
+      };
+      const mockUpdateResource = async () => {
+        throw { code: 'P2025' };
+      };
+
+      const response = await tryUpdateResource(mockRequest, mockRoute, mockUpdateResource);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 500 response with structured error for non-validation errors', async () => {
       const mockRequest = {
         json: async () => ({ id: '123e4567-e89b-12d3-a456-426614174000', name: 'Updated Name' }),
       } as any;
@@ -179,8 +332,10 @@ describe('API Utils', () => {
       };
 
       const response = await tryUpdateResource(mockRequest, mockRoute, mockUpdateResource);
+      const responseData = await response.json();
 
       expect(response.status).toBe(500);
+      expect(responseData.code).toBe('internal_error');
     });
 
     it('should throw error for invalid UUID in route params', async () => {

--- a/tests/storage/car/car.mappers.spec.ts
+++ b/tests/storage/car/car.mappers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { carToDbCar, dbCarToDomain } from '@/storage/car/car.mappers';
+import { carToDbCar, carToDbCarUpdate, dbCarToDomain } from '@/storage/car/car.mappers';
 
 describe('dbCarToDomain', () => {
   it('maps all database car fields to domain Car', () => {
@@ -109,6 +109,38 @@ describe('carToDbCar', () => {
 
     expect(result).toEqual({
       name: 'Test Car',
+    });
+  });
+});
+
+describe('carToDbCarUpdate', () => {
+  it('maps domain Car to Prisma.CarUpdateInput', () => {
+    const testCar = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      name: 'Updated Tesla Model S',
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: new Date('2023-01-02T00:00:00Z'),
+    };
+
+    const result = carToDbCarUpdate(testCar);
+
+    expect(result).toEqual({
+      name: 'Updated Tesla Model S',
+    });
+  });
+
+  it('maps car with different name correctly', () => {
+    const testCar = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'Updated Honda Civic',
+      createdAt: new Date('2024-05-15T10:30:00Z'),
+      updatedAt: new Date('2024-05-16T14:45:00Z'),
+    };
+
+    const result = carToDbCarUpdate(testCar);
+
+    expect(result).toEqual({
+      name: 'Updated Honda Civic',
     });
   });
 });

--- a/tests/storage/car/car.update.spec.ts
+++ b/tests/storage/car/car.update.spec.ts
@@ -8,6 +8,7 @@ vi.mock('@/storage/utils', () => ({
 // Mock the car mappers
 vi.mock('@/storage/car/car.mappers', () => ({
   dbCarToDomain: vi.fn(),
+  carToDbCarUpdate: vi.fn((car) => ({ name: car.name })),
 }));
 
 import { dbCarUpdate } from '@/storage/car/car.update';

--- a/tests/storage/utils.spec.ts
+++ b/tests/storage/utils.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the Prisma adapters and client
 vi.mock('@prisma/adapter-neon', () => ({
@@ -16,10 +16,14 @@ vi.mock('@/storage/client/client', () => ({
 import { PrismaNeon } from '@prisma/adapter-neon';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@/storage/client/client';
-import { getPrismaClient } from '@/storage/utils';
 
 describe('getPrismaClient', () => {
   const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset modules to clear the singleton between tests
+    vi.resetModules();
+  });
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -27,13 +31,15 @@ describe('getPrismaClient', () => {
     process.env = { ...originalEnv };
   });
 
-  it('throws an error when DATABASE_URL is not set', () => {
+  it('throws an error when DATABASE_URL is not set', async () => {
     delete process.env.DATABASE_URL;
+
+    const { getPrismaClient } = await import('@/storage/utils');
 
     expect(() => getPrismaClient()).toThrow('DATABASE_URL is not set');
   });
 
-  it('uses PrismaNeon adapter when DATABASE_URL contains .neon.tech', () => {
+  it('uses PrismaNeon adapter when DATABASE_URL contains .neon.tech', async () => {
     const neonUrl = 'postgresql://user:pass@ep-example.region.neon.tech/db?sslmode=require';
     process.env.DATABASE_URL = neonUrl;
 
@@ -43,6 +49,7 @@ describe('getPrismaClient', () => {
     vi.mocked(PrismaNeon).mockReturnValue(mockPrismaNeon as any);
     vi.mocked(PrismaClient).mockReturnValue(mockPrismaClient as any);
 
+    const { getPrismaClient } = await import('@/storage/utils');
     const result = getPrismaClient();
 
     expect(PrismaNeon).toHaveBeenCalledTimes(1);
@@ -53,7 +60,7 @@ describe('getPrismaClient', () => {
     expect(result).toBe(mockPrismaClient);
   });
 
-  it('uses PrismaPg adapter when DATABASE_URL does not contain .neon.tech', () => {
+  it('uses PrismaPg adapter when DATABASE_URL does not contain .neon.tech', async () => {
     const pgUrl = 'postgresql://user:pass@localhost:5432/db';
     process.env.DATABASE_URL = pgUrl;
 
@@ -63,6 +70,7 @@ describe('getPrismaClient', () => {
     vi.mocked(PrismaPg).mockReturnValue(mockPrismaPg as any);
     vi.mocked(PrismaClient).mockReturnValue(mockPrismaClient as any);
 
+    const { getPrismaClient } = await import('@/storage/utils');
     const result = getPrismaClient();
 
     expect(PrismaPg).toHaveBeenCalledTimes(1);
@@ -71,5 +79,27 @@ describe('getPrismaClient', () => {
     expect(PrismaClient).toHaveBeenCalledTimes(1);
     expect(PrismaClient).toHaveBeenCalledWith({ adapter: mockPrismaPg });
     expect(result).toBe(mockPrismaClient);
+  });
+
+  it('returns the same instance on subsequent calls (singleton pattern)', async () => {
+    const pgUrl = 'postgresql://user:pass@localhost:5432/db';
+    process.env.DATABASE_URL = pgUrl;
+
+    const mockPrismaPg = { connectionString: pgUrl };
+    const mockPrismaClient = { isMockClient: true };
+
+    vi.mocked(PrismaPg).mockReturnValue(mockPrismaPg as any);
+    vi.mocked(PrismaClient).mockReturnValue(mockPrismaClient as any);
+
+    const { getPrismaClient } = await import('@/storage/utils');
+
+    const result1 = getPrismaClient();
+    const result2 = getPrismaClient();
+    const result3 = getPrismaClient();
+
+    // Should only create one instance
+    expect(PrismaClient).toHaveBeenCalledTimes(1);
+    expect(result1).toBe(result2);
+    expect(result2).toBe(result3);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes API response shapes and introduces new 404 handling for read/update/delete, which could affect client expectations and error handling paths. Core behavior is otherwise straightforward and covered by updated tests.
> 
> **Overview**
> Standardizes API error handling by returning structured JSON error bodies (`validation_error`, `internal_error`, `id_mismatch`, `not_found`) instead of empty objects, and adds shared helpers in `app/api/utils.ts` for `GET`/`DELETE` to map Prisma not-found errors (e.g. `P2025`/`P2016`) or `NotFoundError` to HTTP 404.
> 
> Tightens validation by enforcing non-null UUIDs on `updateCar` and making `carSchema` (and `carFilterSchema`) `.strict()`, refactors car update persistence to use a dedicated `carToDbCarUpdate` mapper, and makes `getPrismaClient` a singleton to reuse the Prisma client across calls. Tests are updated/added to cover the new error formats, 404 behavior, and Prisma client singleton behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6579362df33e95caa1390d7154c76962da44c9bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->